### PR TITLE
Updated nokogiri dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "nokogiri", "~> 1.4.0"
+gem "nokogiri", "~> 1.5.0"
 gem "gccxml_gem", "~>0.9.0"
 
 group :development do

--- a/rbgccxml.gemspec
+++ b/rbgccxml.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.author = 'Jason Roelofs'
   s.email = 'jasongroelofs@gmail.com'
 
-  s.add_dependency "nokogiri", "~> 1.4.0"
+  s.add_dependency "nokogiri", "~> 1.5.0"
   s.add_dependency "gccxml_gem", "~> 0.9"
 
   s.description = <<-END


### PR DESCRIPTION
Hi,

To get this gem working on my Ubuntu 12.10 machine I had to update the nokogiri version dependency.

The error I was getting on install was:

make
compiling xslt_stylesheet.c
compiling xml_relax_ng.c
compiling xml_xpath_context.c
xml_xpath_context.c: In function ‘xpath_generic_exception_handler’:
xml_xpath_context.c:184:3: error: format not a string literal and no format arguments [-Werror=format-security]
cc1: some warnings being treated as errors
make: **\* [xml_xpath_context.o] Error 1
