### PR TITLE
allow Nokogiri to upgrade to avoid deprecation warning about Fixnum

### DIFF
--- a/rbgccxml.gemspec
+++ b/rbgccxml.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.author = 'Jason Roelofs'
   s.email = 'jasongroelofs@gmail.com'
 
-  s.add_dependency "nokogiri", ">= 1.5.0", "< 1.7.0"
+  s.add_dependency "nokogiri", ">= 1.5.0"
 
   s.description = <<-END
 Rbgccxml is a library that parses out GCCXML (http://www.gccxml.org) output


### PR DESCRIPTION
Nokogiri is only used once (in lib/rbgccxml/sax_parser.rb) for `Nokogiri::XML::SAX` and that interface has not changed.